### PR TITLE
[WIP] candy:core.presence triggerHandler

### DIFF
--- a/src/core/event.js
+++ b/src/core/event.js
@@ -151,14 +151,18 @@ Candy.Core.Event = (function(self, Strophe, $) {
 					self.Jabber.Room.Presence(msg);
 				}
 			} else {
+				// Find the proper contact for from:
+				var fromUser = Candy.Core.getRoster().get(msg.attr('from'));
+
 				/** Event: candy:core.presence
 				 * Presence updates. Emitted only when not a muc presence.
 				 *
 				 * Parameters:
-				 *   (JID) from - From Jid
-				 *   (String) stanza - Stanza
+				 *   (Candy.Core.Contact) from - Contact user object
 				 */
-				$(Candy).triggerHandler('candy:core.presence', {'from': msg.attr('from'), 'stanza': msg});
+				$(Candy).triggerHandler('candy:core.presence', {
+					'from': fromUser
+				});
 			}
 			return true;
 		},


### PR DESCRIPTION
This trigger is used within Candy core here: https://github.com/mojolingo/candy/blob/dev/src/view.js#L69 which really calls this here: https://github.com/mojolingo/candy/blob/dev/src/view/observer.js#L150-L227

No where in that does it call `args.from` or `args.stanza`. So uh, I'm not really sure how this is working unless the functionality was fixed/duplicated somewhere else?

I'd like another set of eyes on this to make sure I'm not totally overlooking something.
