### PR TITLE
Correct check for undefined variable

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -167,7 +167,7 @@ Candy.Core = (function(self, Strophe, $) {
 
 		// Enable debug logging
 		if(_options.debug) {
-			if(typeof window.console !== undefined && typeof window.console.log !== undefined) {
+			if(typeof window.console !== 'undefined' && typeof window.console.log !== 'undefined') {
 				// Strophe has a polyfill for bind which doesn't work in IE8.
 				if(Function.prototype.bind && Candy.Util.getIeVersion() > 8) {
 					self.log = Function.prototype.bind.call(console.log, console);


### PR DESCRIPTION
The code was comparing the result of `typeof` with a variable named `undefined`. 

As typeof returns a string it should compare to `'undefined'`.
